### PR TITLE
Use temp file instead of hardcoded file name

### DIFF
--- a/sudobash.sh
+++ b/sudobash.sh
@@ -5,53 +5,51 @@
 # Created 2006 summer
 #####################################################
 
-sed 's/[0-9]/&\n/g'< "$1" > ttt
+set -euo pipefail
+
+tmp_file="$(mktemp)"
+
+sed 's/[0-9]/&\n/g'< "$1" > "$tmp_file"
 {
 for ((i=0;i<=80;i++))
 do
   read -r a[$i]
 done
-} < ttt
+} < "$tmp_file"
 
-rm ttt
-
+# Brute-force
 sudoku () {
-    local i
-    local j
-    local k
-    for ((i=0;i<=80;i++))
-    do
-
-        if [ "${a[$i]}" -ne 0  ]
-        then
-        continue
-        fi
-        local non_cand=
-        for ((j=0;j<=80;j++))
-        do
-        if (( j / 9 == i / 9 || j % 9 == i % 9 || j / 27 == i / 27 && j % 9 / 3 == i % 9 / 3 ))
-        then
-            non_cand=${non_cand}${a[$j]}
-        fi
-        done
-        local cand
-        cand="$(echo "123456789" | tr -d "$non_cand")"
-        for ((k=1;k<=9;k++))
-        do
-        if echo -n "$cand" | grep -q "$k"
-        then a[$i]=$k
-        sudoku
-        fi
-        done
-        a[$i]=0
-        return
-    done
-    for ((k=0;k<=80;k++))
-    do
-        echo -n ${a[$k]}
-    done
-    echo
-    exit 0
+	local i
+	local j
+	local k
+	for ((i=0;i<=80;i++)); do
+		if [ "${a[$i]}" -ne 0  ]; then
+		  continue
+		fi
+		local non_cand
+		non_cand=""
+		for ((j=0;j<=80;j++)); do
+		  if (( j / 9 == i / 9 || j % 9 == i % 9 || j / 27 == i / 27 && j % 9 / 3 == i % 9 / 3 ))
+		  then
+			  non_cand=${non_cand}${a[$j]}
+		  fi
+		done
+		local cand
+		cand="$(echo "123456789" | tr -d "$non_cand")"
+		for ((k=1;k<=9;k++)); do
+		  if echo -n "$cand" | grep -q "$k"; then
+			  a[$i]=$k
+		    sudoku
+		  fi
+		done
+		a[$i]=0
+		return
+	done
+	for ((k=0;k<=80;k++)); do
+		echo -n ${a[$k]}
+	done
+	echo
+	exit 0
 }
 
 sudoku


### PR DESCRIPTION
We use `mktemp` to generate a temporary file for preprocessed input
data.

Also make some minor formatting changes.